### PR TITLE
Rearrange manual gain table calculation to match the gain-setting code more closely.

### DIFF
--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -1244,12 +1244,15 @@ static void r82xx_compute_gain_table(struct r82xx_priv *priv)
 		case GAIN_MODE_AGC: 
 		case GAIN_MODE_MANUAL: 
 		{
-			int lna_index = 0, mixer_index = 0, len = 0;
-			for (i=0; i<15; i++) {
-				r82xx_gain_table[len++] = LNA_stage[lna_index++] + Mixer_stage[mixer_index];
-				r82xx_gain_table[len++] = LNA_stage[lna_index] + Mixer_stage[mixer_index++];
+			int len = 0, total_gain = 0;
+			for (i=1; i<16; i++) {
+				r82xx_gain_table[len++] = total_gain;
+				total_gain += r82xx_lna_gain_steps[i];
+				r82xx_gain_table[len++] = total_gain;
+				total_gain += r82xx_mixer_gain_steps[i];
 			}
-			r82xx_gain_table_len = len - 1;
+			r82xx_gain_table[len++] = total_gain;
+			r82xx_gain_table_len = len;
 			break;
 		}
 		case GAIN_MODE_LINEARITY:

--- a/src/tuner_r82xx.c
+++ b/src/tuner_r82xx.c
@@ -1245,13 +1245,15 @@ static void r82xx_compute_gain_table(struct r82xx_priv *priv)
 		case GAIN_MODE_MANUAL: 
 		{
 			int len = 0, total_gain = 0;
+			r82xx_gain_table[len++] = 0;
 			for (i=1; i<16; i++) {
-				r82xx_gain_table[len++] = total_gain;
 				total_gain += r82xx_lna_gain_steps[i];
-				r82xx_gain_table[len++] = total_gain;
+				if (total_gain > r82xx_gain_table[len-1])
+					r82xx_gain_table[len++] = total_gain;
 				total_gain += r82xx_mixer_gain_steps[i];
+				if (total_gain > r82xx_gain_table[len-1])
+					r82xx_gain_table[len++] = total_gain;
 			}
-			r82xx_gain_table[len++] = total_gain;
 			r82xx_gain_table_len = len;
 			break;
 		}


### PR DESCRIPTION
This fixes a problem where the topmost gain (49.6dB) would be omitted,
but introduces another complication: because there is a negative step
value for mixer gain in the standard gain steps, there's a possible
gain value included in the table of gains that can actually never
be set. Ew. I don't like just dropping the last entry either since
I'm about to fix that negative mixer gain step anyway, but if you
want to do that just make gain_table_len one shorter.
